### PR TITLE
Improve PumpFun chat logger handshake configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+# PumpFun Livestream Chat Logger
+
+Dieses Repository enthält ein kleines Hilfsskript, mit dem sich der Chat des
+PumpFun-Livestreams als Textdatei (NDJSON) sichern lässt. Die einzelnen
+Chat-Nachrichten werden inklusive Zeitstempel abgespeichert und können im
+Anschluss weiter verarbeitet werden – zum Beispiel mit Python, Pandas oder
+anderen Tools, die JSON verarbeiten.
+
+## Installation
+
+1. Optional: Erstelle und aktiviere ein virtuelles Python-Umfeld (z. B. mit
+   `python -m venv .venv && source .venv/bin/activate`).
+2. Installiere die Abhängigkeiten:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+## Verwendung
+
+Das Skript `pumpfun_chat_logger.py` verbindet sich mit dem PumpFun-Socket.IO
+Server und schreibt jede empfangene Chat-Nachricht als JSON-Zeile in die Datei
+`pumpfun_chat.ndjson`. Die wichtigsten Parameter lassen sich über die
+Kommandozeile anpassen, sodass Änderungen am PumpFun-Protokoll schnell
+übernommen werden können.
+
+```bash
+python pumpfun_chat_logger.py \
+  --socket-url https://pumpportal.fun \
+  --subscribe-event subscribe \
+  --subscribe-payload '{"room": "livestream", "channel": "chat"}' \
+  --listen-event chat_message \
+  --output pf_chat.ndjson \
+  --header 'Cookie: cf_clearance=DEIN_WERT; another_cookie=...' \
+  --header 'User-Agent: Mozilla/5.0 ...'
+```
+
+### Nützliche Optionen
+
+- `--append`: hängt neue Nachrichten an eine bestehende Datei an.
+- `--duration 600`: beendet das Skript nach 600 Sekunden automatisch.
+- `--quiet`: unterdrückt die Ausgabe im Terminal (nur Datei wird geschrieben).
+- Mehrfaches `--listen-event`: falls PumpFun mehrere Event-Namen für Chats
+  verwendet, kann dieser Schalter mehrfach angegeben werden.
+- `--header 'Key: Wert'`: ergänzt eigene HTTP-Header für den Socket.IO-Handshake.
+- `--no-default-headers`: deaktiviert die automatisch gesetzten Browser-Header,
+  falls du alle Felder selbst angeben möchtest.
+
+## Authentifizierung & Header
+
+Der Socket.IO-Endpunkt `pumpportal.fun` befindet sich hinter einer Web-
+Application-Firewall. Damit die Verbindung akzeptiert wird, muss der Client
+Browser-Header mitsenden (insbesondere `User-Agent`, `Origin`, `Referer`) und
+ggf. gültige Cookies wie `cf_clearance` oder Sitzungs-Token. Standardmäßig
+verschickt das Skript einen typischen Chrome-Header. Zusätzliche Felder kannst
+du mit `--header KEY:VALUE` ergänzen.
+
+Am einfachsten ist es, die Netzwerk-Tools des Browsers zu öffnen und nach dem
+`socket.io`-Handshake der PumpFun-Webseite zu suchen. Kopiere dort sämtliche
+Request-Header oder Cookies und füge sie dem Skript über wiederholte
+`--header`-Argumente hinzu. Falls du deine eigenen Header vollständig angeben
+möchtest, kannst du die Standardeinträge mit `--no-default-headers` deaktivieren.
+
+## Ermittlung der richtigen Events
+
+Die genauen Event-Namen und Payload-Strukturen können sich ändern. Mit den
+Entwickler-Tools des Browsers (Tab „Netzwerk“) lässt sich beobachten, welche
+Nachrichten die PumpFun-Webseite beim Beitritt zum Livestream verschickt. Diese
+Informationen kannst du direkt an das Skript weiterreichen, ohne den Code
+ändern zu müssen.
+
+## Ausgabeformat
+
+Jede Zeile der Ausgabedatei enthält einen JSON-Datensatz mit:
+
+- `timestamp`: Zeitpunkt des Empfangs im ISO-8601-Format (UTC).
+- `event`: Name des Socket.IO-Events.
+- `data`: Unveränderte Nutzlast, die PumpFun gesendet hat.
+
+Die NDJSON-Datei lässt sich beispielsweise mit `jq`, Python oder Datenbank-Tools
+weiter analysieren.

--- a/pumpfun_chat_logger.py
+++ b/pumpfun_chat_logger.py
@@ -1,0 +1,243 @@
+"""PumpFun livestream chat logger.
+
+This script connects to the PumpFun livestream Socket.IO endpoint and records
+incoming chat messages into a newline-delimited JSON (NDJSON) file so the data
+can be post-processed later on.
+
+Because the PumpFun websocket schema is subject to change, the script exposes
+CLI options to adapt the subscribe payload and the events it listens to without
+having to modify the code.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional
+
+import socketio
+
+
+DEFAULT_SOCKET_URL = "https://pumpportal.fun"
+DEFAULT_SUBSCRIBE_EVENT = "subscribe"
+DEFAULT_SUBSCRIBE_PAYLOAD = {
+    "room": "livestream",
+    "channel": "chat",
+}
+DEFAULT_LISTEN_EVENTS = ("chat_message",)
+DEFAULT_HEADERS: Mapping[str, str] = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
+    ),
+    "Origin": "https://pump.fun",
+    "Referer": "https://pump.fun/",
+    "Accept-Language": "en-US,en;q=0.9",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Stream PumpFun livestream chat messages into a text file.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--socket-url",
+        default=DEFAULT_SOCKET_URL,
+        help="Socket.IO endpoint serving the PumpFun livestream feed.",
+    )
+    parser.add_argument(
+        "--subscribe-event",
+        default=DEFAULT_SUBSCRIBE_EVENT,
+        help="Socket.IO event name used to subscribe to the livestream room.",
+    )
+    parser.add_argument(
+        "--subscribe-payload",
+        default=json.dumps(DEFAULT_SUBSCRIBE_PAYLOAD),
+        help=(
+            "JSON payload used for the subscription message. "
+            "The payload must be compatible with PumpFun's Socket.IO server."
+        ),
+    )
+    parser.add_argument(
+        "--listen-event",
+        action="append",
+        dest="listen_events",
+        default=list(DEFAULT_LISTEN_EVENTS),
+        help=(
+            "Socket.IO event(s) carrying chat messages. "
+            "Can be supplied multiple times; each event is persisted."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("pumpfun_chat.ndjson"),
+        help="Destination file for the chat log (newline-delimited JSON).",
+    )
+    parser.add_argument(
+        "--append",
+        action="store_true",
+        help="Append to the output file instead of truncating it.",
+    )
+    parser.add_argument(
+        "--duration",
+        type=int,
+        default=None,
+        help="Optional maximum run time in seconds; leave empty to run forever.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress console output for each received message.",
+    )
+    parser.add_argument(
+        "--header",
+        action="append",
+        dest="headers",
+        default=[],
+        metavar="KEY:VALUE",
+        help=(
+            "Additional HTTP headers for the Socket.IO handshake. "
+            "Repeat the flag to append multiple headers."
+        ),
+    )
+    parser.add_argument(
+        "--no-default-headers",
+        action="store_true",
+        help="Do not send the built-in browser-style headers when connecting.",
+    )
+    return parser.parse_args()
+
+
+class PumpFunChatLogger:
+    def __init__(
+        self,
+        socket_url: str,
+        subscribe_event: str,
+        subscribe_payload: Dict[str, Any],
+        listen_events: Iterable[str],
+        output: Path,
+        append: bool = False,
+        quiet: bool = False,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> None:
+        self._socket_url = socket_url
+        self._subscribe_event = subscribe_event
+        self._subscribe_payload = subscribe_payload
+        self._listen_events = tuple(dict.fromkeys(listen_events))
+        self._output_path = output
+        self._append = append
+        self._quiet = quiet
+        self._headers = dict(headers or {})
+        self._sio = socketio.AsyncClient(logger=False, engineio_logger=False)
+        self._file_handle = None
+
+        self._register_handlers()
+
+    def _register_handlers(self) -> None:
+        @self._sio.event
+        async def connect() -> None:  # type: ignore[override]
+            if not self._quiet:
+                print("Connected to PumpFun websocket; subscribing to chat feed...")
+            await self._sio.emit(self._subscribe_event, self._subscribe_payload)
+
+        @self._sio.event
+        async def connect_error(data: Any) -> None:  # type: ignore[override]
+            print(f"Connection error: {data}")
+
+        @self._sio.event
+        async def disconnect() -> None:  # type: ignore[override]
+            if not self._quiet:
+                print("Disconnected from PumpFun websocket.")
+
+        async def message_handler(event: str, data: Any) -> None:
+            payload = {
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "event": event,
+                "data": data,
+            }
+            self._file_handle.write(json.dumps(payload, ensure_ascii=False))
+            self._file_handle.write("\n")
+            self._file_handle.flush()
+            if not self._quiet:
+                print(f"[{payload['timestamp']}] {event}: {data}")
+
+        for event_name in self._listen_events:
+            if not event_name:
+                continue
+
+            @self._sio.on(event_name)  # type: ignore[misc]
+            async def _handler(data: Any, event=event_name) -> None:
+                await message_handler(event, data)
+
+    async def run(self, duration: Optional[int] = None) -> None:
+        mode = "a" if self._append else "w"
+        self._output_path.parent.mkdir(parents=True, exist_ok=True)
+        with self._output_path.open(mode, encoding="utf-8") as handle:
+            self._file_handle = handle
+            await self._sio.connect(
+                self._socket_url,
+                transports=["websocket"],
+                headers=self._headers or None,
+            )
+
+            try:
+                if duration is not None:
+                    await asyncio.wait_for(self._sio.wait(), timeout=duration)
+                else:
+                    await self._sio.wait()
+            except asyncio.TimeoutError:
+                if not self._quiet:
+                    print("Duration reached; closing connection.")
+            finally:
+                await self._sio.disconnect()
+
+
+def main() -> None:
+    args = parse_args()
+    try:
+        subscribe_payload = json.loads(args.subscribe_payload)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid JSON for --subscribe-payload: {exc}") from exc
+
+    header_map: Dict[str, str] = {}
+    if not args.no_default_headers:
+        header_map.update(DEFAULT_HEADERS)
+
+    for header in args.headers:
+        if ":" not in header:
+            raise SystemExit(
+                "Malformed --header value. Expected KEY:VALUE, "
+                f"got {header!r}."
+            )
+        key, value = header.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            raise SystemExit("Header name cannot be empty.")
+        header_map[key] = value
+
+    logger = PumpFunChatLogger(
+        socket_url=args.socket_url,
+        subscribe_event=args.subscribe_event,
+        subscribe_payload=subscribe_payload,
+        listen_events=args.listen_events,
+        output=args.output,
+        append=args.append,
+        quiet=args.quiet,
+        headers=header_map,
+    )
+
+    try:
+        asyncio.run(logger.run(duration=args.duration))
+    except KeyboardInterrupt:
+        if not args.quiet:
+            print("Interrupted by user; shutting down...")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-socketio[client]==5.11.2


### PR DESCRIPTION
## Summary
- add browser-style default headers and CLI switches for customizing the PumpFun Socket.IO handshake
- expose header parsing in the logger and document how to supply cf_clearance and other required values
- update README usage guidance with new options for custom headers and disabling defaults

## Testing
- python -m compileall pumpfun_chat_logger.py

------
https://chatgpt.com/codex/tasks/task_e_68e5641d0ef48333aedddec06cc6fdad